### PR TITLE
Disable Jekyll processing for GitHub Pages

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll so underscore-prefixed files are served


### PR DESCRIPTION
## Summary
- add a `.nojekyll` marker file so GitHub Pages will serve `_sidebar.md` and other underscored assets without filtering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d457cfb59883279f5c81ac07fad979